### PR TITLE
Add an enable_implicit_network_policy port option

### DIFF
--- a/stackpath/internal/models/v1_instance_port.go
+++ b/stackpath/internal/models/v1_instance_port.go
@@ -14,6 +14,10 @@ import (
 // V1InstancePort A network port to be opened to the Internet on an instance of a workload
 // swagger:model v1InstancePort
 type V1InstancePort struct {
+	// Allow the internet to connect to the port
+	//
+	// When true, this port will be given an implicit network policy of priority 65534 permitting 0.0.0.0/0 access to the port. This can be overridden by creating network policies of a higher priority to block the port.
+	EnableImplicitNetworkPolicy bool `json:"enableImplicitNetworkPolicy,omitempty"`
 
 	// The network port to listen on
 	Port int32 `json:"port,omitempty"`

--- a/stackpath/resource_stackpath_compute_network_policy_test.go
+++ b/stackpath/resource_stackpath_compute_network_policy_test.go
@@ -24,7 +24,7 @@ func TestAccComputeNetworkPolicy(t *testing.T) {
 		},
 		CheckDestroy: testAccComputeNetworkPolicyCheckDestroy(),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeNetworkPolicyConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeCheckNetworkPolicyExists("stackpath_compute_network_policy.foo", networkPolicy),
@@ -52,7 +52,7 @@ func testAccComputeCheckNetworkPolicyExists(name string, policy *models.V1Networ
 			Context:         context.Background(),
 		}, nil)
 		if err != nil {
-			return fmt.Errorf("Could not retrieve network policy: %v", err)
+			return fmt.Errorf("could not retrieve network policy: %v", err)
 		}
 
 		*policy = *found.Payload.NetworkPolicy
@@ -90,48 +90,48 @@ func testAccComputeNetworkPolicyCheckDestroy() resource.TestCheckFunc {
 func testAccComputeNetworkPolicyConfigBasic() string {
 	return fmt.Sprintf(`
 resource "stackpath_compute_network_policy" "foo" {
-	name = "test-terraform-workload-allow-port-80"
-	slug = "test-terraform-workload-allow-port-80"
+  name = "test-terraform-workload-allow-port-80"
+  slug = "test-terraform-workload-allow-port-80"
 
-	instance_selector {
-		key      = "workload.platform.stackpath.net/workload-slug"
-		operator = "in"
-		values = [
-			"my-terraform-workload"
-		]
-	}
+  instance_selector {
+    key      = "workload.platform.stackpath.net/workload-slug"
+    operator = "in"
+    values = [
+      "my-terraform-workload"
+    ]
+  }
 
-	policy_types = ["INGRESS", "EGRESS"]
+  policy_types = ["INGRESS", "EGRESS"]
 
-	priority = 1000
+  priority = 1000
 
-	ingress {
-		# Configure the network policy to allow traffic from
-		# the source CIDR range of 0.0.0.0/0 (all traffic) to
-		# hit port 80.
-		description = "Allow all port 80 traffic"
-		action      = "ALLOW"
-		protocol {
-			tcp {
-				# configure the destination ports that should be allowed
-				destination_ports = [80]
-			}
-		}
-		from {
-			ip_block {
-				cidr = "0.0.0.0/0"
-			}
-		}
-	}
+  ingress {
+    # Configure the network policy to allow traffic from
+    # the source CIDR range of 0.0.0.0/0 (all traffic) to
+    # hit port 80.
+    description = "Allow all port 80 traffic"
+    action      = "ALLOW"
+    protocol {
+      tcp {
+        # configure the destination ports that should be allowed
+        destination_ports = [80]
+      }
+    }
+    from {
+      ip_block {
+        cidr = "0.0.0.0/0"
+      }
+    }
+  }
 
-	egress {
-		description = "Allow all outbound traffic"
-		action      = "ALLOW"
-		to {
-			ip_block {
-				cidr = "0.0.0.0/0"
-			}
-		}
-	}
+  egress {
+    description = "Allow all outbound traffic"
+    action      = "ALLOW"
+    to {
+      ip_block {
+        cidr = "0.0.0.0/0"
+      }
+    }
+  }
 }`)
 }

--- a/stackpath/resource_stackpath_compute_workload.go
+++ b/stackpath/resource_stackpath_compute_workload.go
@@ -350,6 +350,11 @@ func resourceComputeWorkloadPortSchema() *schema.Schema {
 					Type:     schema.TypeString,
 					Required: true,
 				},
+				"enable_implicit_network_policy": &schema.Schema{
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 				"port": &schema.Schema{
 					Type:     schema.TypeInt,
 					Required: true,

--- a/stackpath/resource_stackpath_compute_workload_test.go
+++ b/stackpath/resource_stackpath_compute_workload_test.go
@@ -35,7 +35,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigContainerBasic(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
@@ -45,7 +45,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 					testAccComputeWorkloadCheckTarget(workload, "us", "cityCode", "in", 1, "AMS"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigContainerAddPorts(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
@@ -56,7 +56,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 					testAccComputeWorkloadCheckTarget(workload, "us", "cityCode", "in", 2, "AMS"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigContainerRemoveEnvVar(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
@@ -67,7 +67,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 					testAccComputeWorkloadCheckTarget(workload, "us", "cityCode", "in", 2, "AMS"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigContainerAddProbes(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
@@ -78,7 +78,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 					testAccComputeWorkloadCheckTarget(workload, "us", "cityCode", "in", 2, "AMS"),
 				),
 			},
-			resource.TestStep{
+			{
 				ExpectError: emptyImagePullSecrets,
 				Config:      testComputeWorkloadConfigContainerImagePullCredentials(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
@@ -87,7 +87,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 					testAccComputeWorkloadCheckImagePullCredentials(workload, "docker.io", "my-registry-user", "developers@stackpath.com"),
 				),
 			},
-			resource.TestStep{
+			{
 				ExpectError: emptyImagePullSecrets,
 				Config:      testComputeWorkloadConfigAutoScalingConfiguration(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
@@ -99,7 +99,7 @@ func TestComputeWorkloadContainers(t *testing.T) {
 			// TODO: there's a ordering issue where the order of the containers is shuffled when being read in from the API
 			//   Need to ensure consistent ordering of containers when reading in state.
 			//
-			// resource.TestStep{
+			// {
 			// 	Config: testComputeWorkloadConfigContainerAddContainer(),
 			// 	Check: resource.ComposeTestCheckFunc(
 			// 		testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo", workload),
@@ -124,13 +124,13 @@ func TestComputeWorkloadContainersAdditionalVolume(t *testing.T) {
 		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigContainerAddVolumeMounts(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.foo-volume", workload),
 					testAccComputeWorkloadCheckContainerImage(workload, "app", "nginx:latest"),
 					testAccComputeWorkloadAdditionalVolume(workload, "volume", "10Gi"),
-					testAccComputeWorlloadContainerVolumeMount(workload, "app", "volume", "/var/log"),
+					testAccComputeWorkloadContainerVolumeMount(workload, "app", "volume", "/var/log"),
 				),
 			},
 		},
@@ -150,7 +150,7 @@ func TestComputeWorkloadVirtualMachines(t *testing.T) {
 		},
 		CheckDestroy: testAccComputeWorkloadCheckDestroy(),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testComputeWorkloadConfigVirtualMachineBasic(nameSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeWorkloadCheckExists("stackpath_compute_workload.bar", workload),
@@ -177,11 +177,11 @@ func testAccComputeWorkloadCheckDestroy() resource.TestCheckFunc {
 				WorkloadID: rs.Primary.ID,
 				Context:    context.Background(),
 			}, nil)
-			// Since compute workloads are deleted asyncronously, we want to look at the fact that
+			// Since compute workloads are deleted asynchronously, we want to look at the fact that
 			// the deleteRequestedAt timestamp was set on the workload. This field is used to indicate
 			// that the workload is being deleted.
 			if err == nil && resp.Payload.Workload.Metadata.DeleteRequestedAt == nil {
-				return fmt.Errorf("Compute workload still exists: %v", rs.Primary.ID)
+				return fmt.Errorf("compute workload still exists: %v", rs.Primary.ID)
 			}
 		}
 
@@ -189,7 +189,7 @@ func testAccComputeWorkloadCheckDestroy() resource.TestCheckFunc {
 	}
 }
 
-func testAccComputeWorlloadContainerVolumeMount(workload *models.V1Workload, containerName, volumeSlug, mountPath string) resource.TestCheckFunc {
+func testAccComputeWorkloadContainerVolumeMount(workload *models.V1Workload, containerName, volumeSlug, mountPath string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
 		container, found := workload.Spec.Containers[containerName]
 		if !found {
@@ -382,7 +382,7 @@ func testAccComputeWorkloadCheckExists(name string, workload *models.V1Workload)
 			Context:    context.Background(),
 		}, nil)
 		if err != nil {
-			return fmt.Errorf("Could not retrieve workload: %v", err)
+			return fmt.Errorf("could not retrieve workload: %v", err)
 		}
 
 		*workload = *found.Payload.Workload
@@ -428,11 +428,11 @@ resource "stackpath_compute_workload" "foo" {
     name  = "app"
     image = "nginx:latest"
     resources {
-		requests = {
-			cpu    = "1"
-			memory = "2Gi"
-		}
-	}
+      requests = {
+        cpu    = "1"
+        memory = "2Gi"
+      }
+    }
     port {
       name     = "http"
       port     = 80
@@ -471,21 +471,21 @@ resource "stackpath_compute_workload" "foo" {
     name  = "app"
     image = "nginx:latest"
     resources {
-		requests = {
-			cpu    = "1"
-			memory = "2Gi"
-		}
-	}
-	port {
-      name     = "http"
-      port     = 80
-      protocol = "TCP"
+      requests = {
+        cpu    = "1"
+        memory = "2Gi"
+      }
+    }
+    port {
+      name                           = "http"
+      port                           = 80
+      protocol                       = "TCP"
       enable_implicit_network_policy = false
     }
     port {
-        name     = "https"
-        port     = 443
-        protocol = "TCP"
+      name                           = "https"
+      port                           = 443
+      protocol                       = "TCP"
       enable_implicit_network_policy = true
     }
     env {
@@ -521,11 +521,11 @@ resource "stackpath_compute_workload" "foo" {
     name  = "app"
     image = "nginx:latest"
     resources {
-		requests = {
-			cpu    = "1"
-			memory = "2Gi"
-		}
-	}
+      requests = {
+        cpu    = "1"
+        memory = "2Gi"
+      }
+    }
     port {
       name     = "http"
       port     = 80
@@ -560,11 +560,11 @@ resource "stackpath_compute_workload" "foo" {
     name  = "app"
     image = "nginx:latest"
     resources {
-		requests = {
-			cpu    = "1"
-			memory = "2Gi"
-		}
-	}
+      requests = {
+        cpu    = "1"
+        memory = "2Gi"
+      }
+    }
     port {
       name     = "http"
       port     = 80
@@ -632,11 +632,11 @@ resource "stackpath_compute_workload" "foo" {
     name  = "app"
     image = "nginx:latest"
     resources {
-		requests = {
-			cpu    = "1"
-			memory = "2Gi"
-		}
-	}
+      requests = {
+        cpu    = "1"
+        memory = "2Gi"
+      }
+    }
   }
 
   target {
@@ -709,19 +709,19 @@ resource "stackpath_compute_workload" "bar" {
 
   virtual_machine {
     name  = "app"
-	image = "stackpath-edge/centos-7:v201905012051"
-	port {
-		name     = "http"
-		port     = 80
-		protocol = "TCP"
-	}
+    image = "stackpath-edge/centos-7:v201905012051"
+    port {
+      name     = "http"
+      port     = 80
+      protocol = "TCP"
+    }
     resources {
       requests = {
         cpu    = "1"
         memory = "2Gi"
       }
     }
-	user_data = <<EOT
+    user_data = <<EOT
 package_update: true
 packages:
 - nginx

--- a/stackpath/structure_compute_workload.go
+++ b/stackpath/structure_compute_workload.go
@@ -260,8 +260,9 @@ func convertComputeWorkloadPorts(prefix string, data *schema.ResourceData) model
 		// track the port names so we can keep track of what needs to be removed
 		portNames[portData["name"]] = true
 		ports[portData["name"].(string)] = models.V1InstancePort{
-			Port:     int32(portData["port"].(int)),
-			Protocol: strings.ToUpper(portData["protocol"].(string)),
+			EnableImplicitNetworkPolicy: portData["enable_implicit_network_policy"].(bool),
+			Port:                        int32(portData["port"].(int)),
+			Protocol:                    strings.ToUpper(portData["protocol"].(string)),
 		}
 	}
 
@@ -715,9 +716,10 @@ func flattenComputeWorkloadPortsOrdered(prefix string, data *schema.ResourceData
 	newPorts := make([]interface{}, data.Get(prefix+".#").(int))
 	for portName, v := range ports {
 		port := map[string]interface{}{
-			"name":     portName,
-			"port":     v.Port,
-			"protocol": v.Protocol,
+			"name":                           portName,
+			"port":                           v.Port,
+			"protocol":                       v.Protocol,
+			"enable_implicit_network_policy": v.EnableImplicitNetworkPolicy,
 		}
 		if index, exists := ordered[portName]; exists {
 			newPorts[index] = port

--- a/website/docs/r/compute_workload.html.markdown
+++ b/website/docs/r/compute_workload.html.markdown
@@ -150,6 +150,7 @@ resource "stackpath_compute_workload" "my-compute-workload" {
 * `name` - (Required) The network port's name.
 * `port` - (Required) The network port's number.
 * `protocol` - (Optional) The network port's protocol, either "tcp" or "udp". Defaults to "tcp".
+* `enable_implicit_network_policy` - (Optional) Whether or not the network port has access to the public Internet. Defaults to `false`. 
 
 ### Volume Claims
 


### PR DESCRIPTION
Add a new option to virtual machine and container network port definitions that controls whether the port has default access to the public Internet. This option is optional and defaults to `false`.

Also clean up test code:
* Start error messages with lower case characters
* Remove extraneous type definitions
* Fix spelling errors