### PR TITLE
Fix network policy updates

### DIFF
--- a/examples/compute-network-policy.tf
+++ b/examples/compute-network-policy.tf
@@ -34,7 +34,7 @@ EOT
   # Below is an example of a label selector that applies the policy all of the
   # instances created by the workload with the slug value "my-compute-workload".
   instance_selector {
-    # Every workload instance is provisioned with a label of the workloa slug
+    # Every workload instance is provisioned with a label of the workload slug
     # that created the instance. Apply the label selector to a specific workload
     # by leveraging the workload slug label.
     key = "workload.platform.stackpath.net/workload-slug"

--- a/stackpath/resource_stackpath_compute_network_policy.go
+++ b/stackpath/resource_stackpath_compute_network_policy.go
@@ -34,6 +34,10 @@ func resourceComputeNetworkPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -400,6 +404,10 @@ func resourceComputeNetworkPolicyRead(data *schema.ResourceData, meta interface{
 		return fmt.Errorf("error setting description: %v", err)
 	}
 
+	if err := data.Set("version", resp.Payload.NetworkPolicy.Metadata.Version); err != nil {
+		return fmt.Errorf("error setting version: %v", err)
+	}
+
 	if err := data.Set("labels", flattenStringMap(convertIPAMToWorkloadStringMapEntry(resp.Payload.NetworkPolicy.Metadata.Labels))); err != nil {
 		return fmt.Errorf("error setting labels: %v", err)
 	}
@@ -440,8 +448,9 @@ func resourceComputeNetworkPolicyUpdate(data *schema.ResourceData, meta interfac
 	networkPolicy.ID = data.Id()
 
 	_, err := config.edgeComputeNetworking.NetworkPolicies.UpdateNetworkPolicy(&network_policies.UpdateNetworkPolicyParams{
-		Context: context.Background(),
-		StackID: config.StackID,
+		Context:         context.Background(),
+		StackID:         config.StackID,
+		NetworkPolicyID: data.Id(),
 		Body: &ipam_models.V1UpdateNetworkPolicyRequest{
 			NetworkPolicy: networkPolicy,
 		},

--- a/stackpath/structure_compute_network_policy.go
+++ b/stackpath/structure_compute_network_policy.go
@@ -13,6 +13,7 @@ func convertComputeNetworkPolicy(data *schema.ResourceData) *ipam_models.V1Netwo
 		Metadata: &ipam_models.NetworkMetadata{
 			Labels:      convertWorkloadToIPAMStringMapEntry(convertToStringMap(data.Get("labels").(map[string]interface{}))),
 			Annotations: convertWorkloadToIPAMStringMapEntry(convertToStringMap(data.Get("annotations").(map[string]interface{}))),
+			Version:     data.Get("version").(string),
 		},
 		Spec: &ipam_models.V1NetworkPolicySpec{
 			Priority:          int32(data.Get("priority").(int)),


### PR DESCRIPTION
Prevent 404 errors at the StackPath API by providing the network policy to update. Prevent 400 errors by providing the policy version to bump.